### PR TITLE
feat: haumea-load all modules as noramlized module functions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,20 +33,19 @@
     load = {
       inputs,
       cell,
-      ...
-    } @ args:
-      with builtins;
-        haumea.lib.load (removeAttrs args ["cell" "inputs"]
-          // {
-            loader = haumea.lib.loaders.scoped;
-            transformer = with haumea.lib.transformers; [
-              liftDefault
-              (hoistLists "_imports" "imports")
-            ];
-            # `self` in paisano refers to `inputs.self.sourceInfo` 😕
-            # but is disallowed in haumea
-            inputs = removeAttrs (inputs // {inherit inputs cell;}) ["self"];
-          });
+      src,
+    }:
+    # modules/profiles are always functions
+    {config, options, ...}:
+      haumea.lib.load {
+        inherit src;
+        loader = haumea.lib.loaders.scoped;
+        transformer = with haumea.lib.transformers; [
+          liftDefault
+          (hoistLists "_imports" "imports")
+        ];
+        inputs = {inherit inputs cell config options;};
+      };
   in
     haumea.lib
     // {


### PR DESCRIPTION
# Context

When loading modules / profiles, users typically want seamless access to `config` et al. from the module system application which they are using.

# Solution

To provide easy access to those values, curry the haumea loader with the module system application arguments to the effect that the user can simply use them for example like so:

```nix
# home manager module system application
# programs/password-store.nix
# using `pkgs` & `config`
let
  inherit (config.modules._args) pkgs;
in
{
  enable = true;
  package = pkgs.passage; # pass for age
  settings = {
    PASSAGE_DIR = "${config.xdg.dataHome}/passage";
  };
}
```

Just to reassure, `inputs` & `cell` are available as usual:
```nix
let
  inherit (inputs) nixpkgs;
  inherit (inputs.cell.my-colleague) theirProfiles;
  inherit (cell) myProfiles;
in { ... }
```
