### PR TITLE
feat: set default location on haumea loaded modules for deduplication

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "call-flake": {
+      "locked": {
+        "lastModified": 1687380775,
+        "narHash": "sha256-bmhE1TmrJG4ba93l9WQTLuYM53kwGQAjYHRvHOeuxWU=",
+        "owner": "divnix",
+        "repo": "call-flake",
+        "rev": "74061f6c241227cd05e79b702db9a300a2e4131a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "call-flake",
+        "type": "github"
+      }
+    },
     "colmena": {
       "locked": {
         "lastModified": 1625557891,
@@ -114,6 +129,7 @@
     },
     "paisano": {
       "inputs": {
+        "call-flake": "call-flake",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -121,11 +137,11 @@
         "yants": "yants"
       },
       "locked": {
-        "lastModified": 1678562978,
-        "narHash": "sha256-GaPyKdB0RvSBIgPxKkdJHTG/FyKsT0Ku5zifLEjr3QQ=",
+        "lastModified": 1691492062,
+        "narHash": "sha256-9izEr9crBjoBk4ecuTyFVYwjbXo1VjClRN1eaGITeag=",
         "owner": "divnix",
         "repo": "paisano",
-        "rev": "f71a2db9414d66663c03a65ade97a9f353fb6d55",
+        "rev": "218a7f50451cbc5c981fc8dfe6f962044041f9aa",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -30,14 +30,18 @@
 
     # compat wrapper for humea.lib.load
     inherit (inputs) haumea;
+    inherit (inputs.nixpkgs) lib;
     load = {
       inputs,
       cell,
       src,
     }:
     # modules/profiles are always functions
-    {config, options, ...}:
-      haumea.lib.load {
+    {config, options, ...}: let
+       cr = cell._cr ++ [ baseNameOf src ];
+       file = "${inputs.self.outPath}#${lib.concatStringsSep "/" cr}";
+    in
+      lib.setDefaultModuleLocation file (haumea.lib.load {
         inherit src;
         loader = haumea.lib.loaders.scoped;
         transformer = with haumea.lib.transformers; [
@@ -45,7 +49,7 @@
           (hoistLists "_imports" "imports")
         ];
         inputs = {inherit inputs cell config options;};
-      };
+      });
   in
     haumea.lib
     // {


### PR DESCRIPTION
# Context

When loading a module with `hive.load`, a module key should be set to deduplicate this module when recombining differen sets of modules into module / profile suites

# Solution

Set a default location derived from the cell coursor and the module source basename.

Insipred by: https://github.com/VertexA115/nix-rebar/blob/main/cells/lib/functions/modules/default.nix#L46
