### PR TITLE
implement load finder

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,9 +37,13 @@
       src,
     }:
     # modules/profiles are always functions
-    {config, options, ...}: let
-       cr = cell._cr ++ [ baseNameOf src ];
-       file = "${inputs.self.outPath}#${lib.concatStringsSep "/" cr}";
+    {
+      config,
+      options,
+      ...
+    }: let
+      cr = cell._cr ++ [baseNameOf src];
+      file = "${inputs.self.outPath}#${lib.concatStringsSep "/" cr}";
     in
       lib.setDefaultModuleLocation file (haumea.lib.load {
         inherit src;
@@ -50,10 +54,24 @@
         ];
         inputs = {inherit inputs cell config options;};
       });
+
+    findLoad = {
+      inputs,
+      cell,
+      block,
+    }:
+      with builtins;
+        mapAttrs
+        (n: _:
+          load {
+            inherit inputs cell;
+            src = block + /${n};
+          })
+        (lib.filterAttrs (_: v: v == "directory") (readDir block));
   in
     haumea.lib
     // {
-      inherit load;
+      inherit load findLoad;
       inherit (hive) blockTypes collect;
       inherit (inputs.paisano) grow growOn pick harvest winnow;
     };


### PR DESCRIPTION
- feat: set default location on haumea loaded modules for deduplication
- feat: add a convenience block target load finder

# Context

Boilerplate is inconvenient.

People want to drop in a file and hive should pick it up.

# Solution

Implement a block target finder that also `hive.load`s each target and call it `hive.findLoad`.

## Usage

```nix
# a block, e.g. `nixosProfiles/default.nix`

inputs.hive.findLoad {
  inherit inputs cell;
  block = ./.;
}
```
