### PR TITLE
Fix `hive.load`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
       inputs = removeAttrs (inputs // {inherit inputs;}) ["self"];
     };
 
-    # compat wrapper for humea.lib.load
+    # compat wrapper for haumea.lib.load
     inherit (inputs) haumea;
     inherit (inputs.nixpkgs) lib;
     load = {

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
       options,
       ...
     }: let
-      cr = cell._cr ++ [baseNameOf src];
+      cr = cell.__cr ++ [(baseNameOf src)];
       file = "${inputs.self.outPath}#${lib.concatStringsSep "/" cr}";
     in
       lib.setDefaultModuleLocation file (haumea.lib.load {


### PR DESCRIPTION
There were errors relating to `cell._cr` (which is not found, but `cell.__cr` is) and `baseNameOf` (it shouldn't be an element of the list). This PR fixes those errors.