### PR TITLE
When nixpkgs.pkgs is defined nixpkgs.config is being ignored

### DIFF
--- a/src/transformers/nixosConfigurations.nix
+++ b/src/transformers/nixosConfigurations.nix
@@ -13,7 +13,6 @@
   extraConfig = {
     nixpkgs = {
       inherit (evaled.config.bee) system pkgs;
-      inherit (evaled.config.bee.pkgs) config; # nixos modules don't load this
     };
 
     imports =


### PR DESCRIPTION
# Context
When `nixpkgs.pkgs` is defined `nixpkgs.config` is being ignored
https://github.com/NixOS/nixpkgs/blob/51bc5df898f4fa77bad1f36835801d65e91b9813/nixos/modules/misc/nixpkgs.nix#L160
Recent PR https://github.com/NixOS/nixpkgs/pull/257458, introduce an error
https://github.com/NixOS/nixpkgs/blob/51bc5df898f4fa77bad1f36835801d65e91b9813/nixos/modules/misc/nixpkgs.nix#L383
# Solution
Remove `nixpkgs.config` from transformer