### PR TITLE
fix: do not pass config to nixpgks in nixosConfigurations transformer

### DIFF
--- a/src/transformers/nixosConfigurations.nix
+++ b/src/transformers/nixosConfigurations.nix
@@ -13,7 +13,6 @@
   extraConfig = {
     nixpkgs = {
       inherit (evaled.config.bee) system pkgs;
-      inherit (evaled.config.bee.pkgs) config; # nixos modules don't load this
     };
 
     imports =


### PR DESCRIPTION
Recent changes in nixpkgs favor `pkgs.config` instead of `nixpkgs.config` and while setting will throw an error. With previous behavior, `nixpkgs.config` was silently ignored if `pkgs.config` were present.

We can just skip passing the  `config` to the `nixpkgs`, because we already define `pkgs`.

See: https://github.com/NixOS/nixpkgs/pull/257458, https://github.com/NixOS/nixpkgs/pull/258447