### PR TITLE
feat: add colmena darwin support

### DIFF
--- a/src/transformers/colmenaConfigurations.nix
+++ b/src/transformers/colmenaConfigurations.nix
@@ -7,31 +7,40 @@
   locatedConfig,
 }: let
   l = nixpkgs.lib // builtins;
-
-  inherit (root) beeModule transformers;
+  inherit (root) transformers;
   inherit (inputs) colmena;
 
-  colmenaModules = l.map (l.setDefaultModuleLocation (./colmenaConfigurations.nix + ":colmenaModules")) [
-    # these modules are tied to the below schemaversion
-    # so we fix them here
-    colmena.nixosModules.assertionModule
-    colmena.nixosModules.keyChownModule
-    colmena.nixosModules.keyServiceModule
-    colmena.nixosModules.deploymentOptions
-    {
-      environment.etc."nixos/configuration.nix".text = ''
-        throw '''
-          This machine is not managed by nixos-rebuild, but by colmena.
-        '''
-      '';
-    }
-  ];
+  isDarwin = evaled.config.bee.pkgs.stdenv.isDarwin;
+
+  colmenaModules =
+    l.map (l.setDefaultModuleLocation (./colmenaConfigurations.nix + ":colmenaModules")) [
+      # these modules are tied to the below schemaversion
+      # so we fix them here
+      colmena.nixosModules.assertionModule
+      colmena.nixosModules.keyChownModule
+      colmena.nixosModules.deploymentOptions
+      {
+        environment.etc."nixos/configuration.nix".text = ''
+          throw '''
+            This machine is not managed by nixos-rebuild, but by colmena.
+          '''
+        '';
+      }
+    ]
+    ++ (l.optionals (!isDarwin) [colmena.nixosModules.keyServiceModule]);
 
   config = {
     imports = [locatedConfig] ++ colmenaModules;
   };
 in
-  transformers.nixosConfigurations {
-    inherit evaled;
-    locatedConfig = config;
-  }
+  if isDarwin
+  then
+    transformers.darwinConfigurations {
+      inherit evaled;
+      locatedConfig = config;
+    }
+  else
+    transformers.nixosConfigurations {
+      inherit evaled;
+      locatedConfig = config;
+    }


### PR DESCRIPTION
Test:
```
 Flake.colmenaHive.toplevel.hosts-macbook
warning: Git tree '/home/guangtao/ghq/github.com/divnix/hive' is dirty
trace: warning: lib.nixos.evalModules is experimental and subject to change. See nixos/lib/default.nix
trace: warning: optionsDocBook is deprecated since 23.11 and will be removed in 24.05
trace: warning: optionsDocBook is deprecated since 23.11 and will be removed in 24.05
trace: warning: optionsDocBook is deprecated since 23.11 and will be removed in 24.05
«derivation /nix/store/qn0ikh231sjdajixdrfcb9z6fqx4b956-darwin-system-23.11pre-git+darwin4.8b6ea26.drv»

```