### PR TITLE
fix: workaround growOn issue clobbering load wrapper

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -117,7 +117,7 @@
         (std.blockTypes.devshells "shells" {ci.build = true;})
       ];
     }
-    haumea.lib
+    (removeAttrs haumea.lib ["load"])
     {
       inherit load findLoad;
       inherit (hive) blockTypes collect;


### PR DESCRIPTION
This is a work around I've needed to make use of the `load` function exported by `hive`. Not sure how it's working for anyone else‥ Sorry I forgot to send it in sooner.

This could just as well be an issue with the way paisano `growOn` prioritizes extensions I suppose, and perhaps it should be fixed there?