### PR TITLE
feat: forward additional module inputs through load

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,18 +51,11 @@
       src,
     }:
     # modules/profiles are always functions
-    {
-      config,
-      lib,
-      modulesPath,
-      options,
-      pkgs,
-      ...
-    }: let
+    args: let
       cr = cell.__cr ++ [(baseNameOf src)];
       file = "${self.outPath}#${lib.concatStringsSep "/" cr}";
 
-      i = {inherit inputs cell config lib modulesPath options pkgs;};
+      i = args // {inherit cell inputs;};
       defaultWith = import (haumea + /src/loaders/__defaultWith.nix) {inherit lib;};
       loader = defaultWith (scopedImport i) i;
     in

--- a/flake.nix
+++ b/flake.nix
@@ -53,14 +53,18 @@
     # modules/profiles are always functions
     {
       config,
+      lib,
+      modulesPath,
       options,
+      pkgs,
       ...
     }: let
       cr = cell.__cr ++ [(baseNameOf src)];
       file = "${self.outPath}#${lib.concatStringsSep "/" cr}";
 
+      i = {inherit inputs cell config lib modulesPath options pkgs;};
       defaultWith = import (haumea + /src/loaders/__defaultWith.nix) {inherit lib;};
-      loader = let i = {inherit inputs cell config options;}; in defaultWith (scopedImport i) i;
+      loader = defaultWith (scopedImport i) i;
     in
       if lib.pathIsDirectory src
       then
@@ -71,7 +75,7 @@
             liftDefault
             (hoistLists "_imports" "imports")
           ];
-          inputs = {inherit inputs cell config options;};
+          inputs = i;
         })
       # Mimic haumea for a regular file
       else lib.setDefaultModuleLocation file (loader src);


### PR DESCRIPTION
Previously, files loaded by `load`/`findLoad` were passed `inputs`, `cell`, `config`, and `options`. This failed to cover some use cases, such as using `modulesPath`. This patch alleviates the situation by forwarding the additional module inputs `lib`, `modulesPath`, and `pkgs` through `load`.

These inputs have been chosen as a compromise between convenience and API surface and should cover most common use cases.