### PR TITLE
fix: explicitly mention `pkgs` as module argument

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
       src,
     }:
     # modules/profiles are always functions
-    args: let
+    args @ {pkgs, ...}: let
       cr = cell.__cr ++ [(baseNameOf src)];
       file = "${self.outPath}#${lib.concatStringsSep "/" cr}";
 


### PR DESCRIPTION
The previous change made in PR #31 caused failures when depending on `pkgs` in modules captured by haumea. This is due to the behaviour of `nixpkgs.lib.nixos.evalModules` which does not look up all arguments but only those captured by name explicitly, in addition to `config`, `options`, and `lib` passed by default.

This patch fixes those failures by explicitly making `pkgs` part of the argument list for the module returned by `load`, so that `evalModules` applies the correct argument list.