### PR TITLE
feat: added nixos-rebuild actions to blockTypes/nixosConfigurations

### DIFF
--- a/src/blockTypes/nixosConfigurations.nix
+++ b/src/blockTypes/nixosConfigurations.nix
@@ -50,7 +50,7 @@
               "test"
               "dry-activate"
             ]) (privilegeElevationCommand inputs pkgs)
-            + "nixos-rebuild ${name} --flake . $@";
+            + "nixos-rebuild ${name} --flake "$PRJ_ROOT" $@";
         })
       )
       {

--- a/src/blockTypes/nixosConfigurations.nix
+++ b/src/blockTypes/nixosConfigurations.nix
@@ -24,6 +24,7 @@
       target,
       inputs,
     }: let
+      pkgs = inputs.nixpkgs.${currentSystem};
       getString = o: (l.elemAt (l.splitString ["/"] fragmentRelPath) o);
       host = (getString 0) + "-" + (getString 2);
       dc = getString 1;
@@ -35,9 +36,8 @@
         inherit name description;
         command =
           bin
-          + "${
-            l.optionalString (l.elem name ["switch" "boot" "test" "dry-activate"]) "run0 --setenv=PATH=\"$PATH\" "
-          }nixos-rebuild ${name} --flake . -L --show-trace";
+          + l.optionalString (l.elem name ["switch" "boot" "test" "dry-activate"]) "echo Awaiting privilege elevation...; ${pkgs.systemd}/bin/run0 --setenv=PATH=\"$PATH\" "
+          + "nixos-rebuild ${name} --flake . $@";
       })) {
         switch = "Activate & set as default boot.";
         boot = "Set default boot, run old config.";

--- a/src/blockTypes/nixosConfigurations.nix
+++ b/src/blockTypes/nixosConfigurations.nix
@@ -50,7 +50,7 @@
               "test"
               "dry-activate"
             ]) (privilegeElevationCommand inputs pkgs)
-            + "nixos-rebuild ${name} --flake "$PRJ_ROOT" $@";
+            + "nixos-rebuild ${name} --flake \"$PRJ_ROOT\" $@";
         })
       )
       {

--- a/src/blockTypes/nixosConfigurations.nix
+++ b/src/blockTypes/nixosConfigurations.nix
@@ -36,7 +36,7 @@
         inherit name description;
         command =
           bin
-          + l.optionalString (l.elem name ["switch" "boot" "test" "dry-activate"]) "echo Awaiting privilege elevation...; ${pkgs.systemd}/bin/run0 --setenv=PATH=\"$PATH\" "
+          + l.optionalString (l.elem name ["switch" "boot" "test" "dry-activate"]) "echo Awaiting privilege elevation...; ${pkgs.systemdMinimal}/bin/run0 --setenv=PATH=\"$PATH\" "
           + "nixos-rebuild ${name} --flake . $@";
       })) {
         switch = "Activate & set as default boot.";

--- a/src/blockTypes/nixosConfigurations.nix
+++ b/src/blockTypes/nixosConfigurations.nix
@@ -17,7 +17,40 @@
     type = "nixosConfiguration";
     # nixosGenerator's actions?
     # microvm action?
-    # nixos-rebuild action?
+    actions = {
+      currentSystem,
+      fragment,
+      fragmentRelPath,
+      target,
+      inputs,
+    }: let
+      getString = o: (l.elemAt (l.splitString ["/"] fragmentRelPath) o);
+      host = (getString 0) + "-" + (getString 2);
+      dc = getString 1;
+      bin = ''
+        bin=$(nix build .#${dc}.${host}.system --no-link --print-out-paths)/sw/bin
+        export PATH=$bin:$PATH
+      '';
+    in (l.attrsets.mapAttrsToList (name: description: (mkCommand currentSystem {
+        inherit name description;
+        command =
+          bin
+          + "${
+            l.optionalString (l.elem name ["switch" "boot" "test" "dry-activate"]) "run0 --setenv=PATH=\"$PATH\" "
+          }nixos-rebuild ${name} --flake . -L --show-trace";
+      })) {
+        switch = "Activate & set as default boot.";
+        boot = "Set default boot, run old config.";
+        test = "Build & activate, no boot entry.";
+        build = "Build new config.";
+        dry-build = "Simulate build, show changes.";
+        dry-activate = "Simulate activation, show changes.";
+        edit = "Edit configuration with default editor.";
+        repl = "Opens the configuration in nix repl.";
+        build-vm = "Build script for NixOS virtual machine.";
+        build-vm-with-bootloader = "Build script with host-like bootloader.";
+        list-generations = "List system build generations.";
+      });
   };
 in
   nixosConfigurations


### PR DESCRIPTION
I've tested all actions through the std tui for my personal systems.

## Design Considerations

- I've used `mapAttrsToList` to reduce the amount of boilerplate drastically
- I'm elevating `switch`, `boot`, `test` and `dry-activate` with `run0` - the other command shouldn't need elevated privileges

## Known Issues

- The `edit` action fails -> This seems to be an issue with nixos-rebuild, can be ignored for this PR
- The `repl` action goes through but doesn't `:lf .` (load flake) inside the repl -> This seems to be an issue with nixos-rebuild, can be ignored for this PR
- `run0` was introduced in systemd v256, the actions will fail if an older version of systemd, or another init system is used -> NixOS assumes to be running on systemd and the required version has been out for a few months.

---

That's about it. I'm not set in using `run0` over `sudo`, it's just what my current implementation uses.