### PR TITLE
Fix colmena schema version error

### DIFF
--- a/src/collectors/colmenaConfigurations.nix
+++ b/src/collectors/colmenaConfigurations.nix
@@ -24,7 +24,7 @@
 
   colmenaTopLevelCliSchema = comb:
     l.fix (this: {
-      __schema = "v0";
+      __schema = (import (inputs.colmena + /src/nix/hive/eval.nix) {}).__schema;
 
       nodes = l.mapAttrs (_: c: c.bee._evaled) comb;
       toplevel = l.mapAttrs (_: v: v.config.system.build.toplevel) this.nodes;


### PR DESCRIPTION
Greetings @blaggacao haven't commit in a while.

# Problem
There is an error start appearing today related to a recent change in colmena
https://github.com/zhaofengli/colmena/commit/1f669d4c78fb0b18b8841e139bd99135ef037638
```sh
[INFO ] Enumerating nodes...
error:
       … while calling the 'attrNames' builtin

         at «string»:1:190:

            1| with builtins; let assets = getFlake "path:/tmp/colmena-assets-Kvb5Lj?lastModified=1731048647&narHash=sha256-dsgRLVt9cltZY8tXX8lQGu2076vYNrJcz5x1ntWtmHc%3D"; hive = assets.processFlake; in attrNames hive.nodes
             |                                                                                                                                                                                              ^

       … while evaluating the attribute 'processFlake'

         at /nix/store/lpl3pscn0fjhxn5r1k9qsxysi32yaj82-source/flake.nix:9:5:

            8|   outputs = { self, hive }: {
            9|     processFlake = let
             |     ^
           10|       compatibleSchema = "v0.20241006";

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: The colmenaHive output (schema v0) isn't compatible with this version of Colmena.

       Hint: Use the same version of Colmena as in the Flake input.
[ERROR] -----
[ERROR] Operation failed with error: Child process exited with error code: 1
Hint: Backtrace available - Use `RUST_BACKTRACE=1` environment variable to display a backtrace
```
# Solution
We can no longer hardcode the schema version as `"v0"`.
Import the schema version from `inputs.colmena` instead.